### PR TITLE
Add Pico W support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,5 +23,8 @@ lf_run_lfc(${CMAKE_CURRENT_SOURCE_DIR}/src ${LF_MAIN})
 lf_build_generated_code(${LF_MAIN_TARGET} ${CMAKE_CURRENT_SOURCE_DIR}/src-gen/${LF_MAIN})
 
 target_link_libraries(${LF_MAIN_TARGET} PUBLIC pico_stdlib pico_sync)
+if (PICO_CYW43_SUPPORTED)
+  target_link_libraries(${LF_MAIN_TARGET} PUBLIC pico_cyw43_arch_none)
+endif()
 pico_enable_stdio_usb(${LF_MAIN_TARGET} 1)
 pico_enable_stdio_uart(${LF_MAIN_TARGET} 1)

--- a/src/lib/Led.lf
+++ b/src/lib/Led.lf
@@ -2,7 +2,39 @@ target uC
 
 preamble {=
   #include <pico/stdlib.h>
-  #include <hardware/gpio.h>
+
+  #ifdef CYW43_WL_GPIO_LED_PIN
+  #include "pico/cyw43_arch.h"
+  #endif
+
+  // Perform initialisation
+  static int pico_led_init(void) {
+  #if defined(PICO_DEFAULT_LED_PIN)
+    // A device like Pico that uses a GPIO for the LED will define PICO_DEFAULT_LED_PIN
+    // so we can use normal GPIO functionality to turn the led on and off
+    gpio_init(PICO_DEFAULT_LED_PIN);
+    gpio_set_dir(PICO_DEFAULT_LED_PIN, GPIO_OUT);
+    return PICO_OK;
+  #elif defined(CYW43_WL_GPIO_LED_PIN)
+    // For Pico W devices we need to initialise the driver etc
+    return cyw43_arch_init();
+  #else
+  #error "No LED pin defined for Pico"
+  #endif
+  }
+
+  // Toggle the led
+  static void pico_toggle_led(bool led_on) {
+  #if defined(PICO_DEFAULT_LED_PIN)
+    // Just set the GPIO on or off
+    gpio_put(PICO_DEFAULT_LED_PIN, led_on);
+  #elif defined(CYW43_WL_GPIO_LED_PIN)
+    // Ask the wifi "driver" to set the GPIO on or off
+    cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, led_on);
+  #else
+  #error "No LED pin defined for Pico"
+  #endif
+  }
 =}
 
 /**
@@ -14,17 +46,16 @@ reactor Led {
   state led: bool
 
   reaction(startup) {=
-    gpio_init(25);
-    gpio_set_dir(25, GPIO_OUT);
+    pico_led_init();
   =}
 
   reaction(tog) {=
     self->led = !self->led;
-    gpio_put(25, self->led);
+    pico_toggle_led(self->led);
   =}
 
   reaction(set) {=
     self->led = set->value;
-    gpio_put(25, self->led);
+    pico_toggle_led(self->led);
   =}
 }


### PR DESCRIPTION
This pull request updates the LED reactor, allowing it to work seamlessly with both standard Raspberry Pi Pico devices and Pico W devices (which use a different mechanism for controlling the onboard LED). 

Changes:
* Added new helper functions `pico_led_init` and `pico_toggle_led` in the `Led.lf` preamble to handle LED initialization and toggling for both standard Pico and Pico W devices, using conditional compilation to select the appropriate method.
* Modified `CMakeLists.txt` to link against the `pico_cyw43_arch_none` library when building for Pico W devices, ensuring the correct driver support is included.